### PR TITLE
chore: update Android Gradle plugin to 8.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.1.1" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 


### PR DESCRIPTION
## Summary
- bump Android Gradle plugin to 8.1.1 in settings.gradle and build.gradle
- confirm gradle wrapper uses Gradle 8.12

## Testing
- `gradle tasks` *(fails: /workspace/ColorCollab2/android/local.properties not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba5b928c483229705b940f1ac0206